### PR TITLE
More options

### DIFF
--- a/lib/serialijse.d.ts
+++ b/lib/serialijse.d.ts
@@ -1,5 +1,17 @@
 declare module "serialijse" {
-    export function serialize<T>(object: T, options?: object): string;
+    export type IgnoreSpec = string | RegExp
+
+    export interface SerializeContext {
+      index: any[],
+      objects: any[]
+    }
+
+    export interface SerializeOptions {
+        ignored?: IgnoreSpec[]|IgnoreSpec
+        errorHandler?: (context: SerializeContext, options: SerializeOptions, object: any, _throw: () => any) => any;
+    }
+
+    export function serialize<T>(object: T, options?: SerializeOptions): string;
 
     export function deserialize<T>(serializationString: string): T;
 

--- a/lib/serialijse.js
+++ b/lib/serialijse.js
@@ -261,6 +261,9 @@
         }
 
         var serializingObject = {};
+        var _throw = function () {
+          throw new Error("invalid typeof " + typeof object + " " + JSON.stringify(object, null, " "));
+        }
 
         switch (typeof object) {
             case 'number':
@@ -272,7 +275,11 @@
                 _serialize_object(context,serializingObject, object, options);
                 break;
             default:
-                throw new Error("invalid typeof " + typeof object + " " + JSON.stringify(object, null, " "));
+                if (options.errorHandler) {
+                  options.errorHandler(context, options, object, _throw)
+                } else {
+                  _throw()
+                }
         }
 
         return serializingObject;


### PR DESCRIPTION
This brings better TypeScript definition, and a new option `errorHandler` that can be used to override the default error handling.

It may be used to ignore errors on unsupported property types, like Function.

```javascript
options = {
  errorHandler: (context, options, object, throw_) => {
    if (_.isFunction(object)) {
      // Ignore the error
    } else {
      // Throw the default error
      throw_()
    }
  }
}